### PR TITLE
Set prefix to empty string for scm version tags

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,12 @@ plugins {
     id 'pl.allegro.tech.build.axion-release' version '1.12.0'
 }
 
+scmVersion {
+    tag {
+        prefix = ""
+    }
+}
+
 allprojects {
 
     group 'dev.michallaskowski.mokttp'


### PR DESCRIPTION
Fixing version setting from tags without 'release-' prefix.